### PR TITLE
Remove extra "hubot-" string

### DIFF
--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -6,7 +6,7 @@ See [`src/hello-world.coffee`](src/hello-world.coffee) for full documentation.
 
 ## Installation
 
-Add **hubot-<%= scriptName %>** to your `package.json` file:
+Add **<%= scriptName %>** to your `package.json` file:
 
 ```json
 "dependencies": {


### PR DESCRIPTION
Looks like I accidentally missed the removal of an extra "hubot-" string. My fault for not initially catching this, so here's another PR.
