### PR TITLE
Install grunt-cli on travis.

### DIFF
--- a/app/templates/.travis.yml
+++ b/app/templates/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
+
 node_js:
   - "0.11"
   - "0.10"
+
+before_install: npm install -g grunt-cli
+
 notifications:
   email: false


### PR DESCRIPTION
Grunt doesn't recommend installing grunt-cli in the dev deps, but globally, so travis needs that too.

Also, mind if we put a travis badge in the README?
