### PR TITLE
Fix `npm test` command path

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -34,6 +34,6 @@
   "main": "index.coffee",
 
   "scripts": {
-    "test": "grunt test"
+    "test": "script/test"
   }
 }


### PR DESCRIPTION
This requires global grunt-cli.
We have two solution:
A: `npm install -g grunt-cli` before (e.g. travis-ci: before_script section)
B: Change npm test script path and use `script/test`

I choose the latter, because `script/test` takes account of environment variables
I think.
