### PR TITLE
Update generated index.coffee to use fs.existsSync

### DIFF
--- a/app/templates/index.coffee
+++ b/app/templates/index.coffee
@@ -3,10 +3,9 @@ path = require 'path'
 
 module.exports = (robot, scripts) ->
   scriptsPath = path.resolve(__dirname, 'src')
-  fs.exists scriptsPath, (exists) ->
-    if exists
-      for script in fs.readdirSync(scriptsPath)
-        if scripts? and '*' not in scripts
-          robot.loadFile(scriptsPath, script) if script in scripts
-        else
-          robot.loadFile(scriptsPath, script)
+  if fs.existsSync scriptsPath
+    for script in fs.readdirSync(scriptsPath).sort()
+      if scripts? and '*' not in scripts
+        robot.loadFile(scriptsPath, script) if script in scripts
+      else
+        robot.loadFile(scriptsPath, script)


### PR DESCRIPTION
Script loading should be synchronous, to preserve script load order and
allow the script to behave as expected with the `--config-check` hubot
flag. Also ensure the scripts are loaded in alphabetical order. This
matches how hubot loads scripts from the scripts/ directory.
